### PR TITLE
Fix onSnap crash on iOS when no point id provided.

### DIFF
--- a/ios/Interactable/InteractablePoint.h
+++ b/ios/Interactable/InteractablePoint.h
@@ -18,7 +18,7 @@
 @property (nonatomic, assign) CGFloat tension;
 @property (nonatomic, assign) CGFloat strength;
 @property (nonatomic, assign) CGFloat falloff;
-@property (nonatomic, copy) NSString *id;
+@property (nonatomic, copy) id id;
 @property (nonatomic, copy) InteractableArea *influenceArea;
 @property (nonatomic, assign) BOOL haptics;
 

--- a/ios/Interactable/RCTConvert+Interactable.m
+++ b/ios/Interactable/RCTConvert+Interactable.m
@@ -23,7 +23,7 @@
     point.tension = [self CGFloat:json[@"tension"] ?: @(300.0)];
     point.strength = [self CGFloat:json[@"strength"] ?: @(400.0)];
     point.falloff = [self CGFloat:json[@"falloff"] ?: @(40.0)];
-    point.id = [self NSString:json[@"id"] ?: nil];
+    point.id = [self id:json[@"id"] ?: [NSNull null]];
     point.influenceArea = [self InteractableArea:json[@"influenceArea"] ?: nil];
     point.haptics = [self BOOL:json[@"haptics"] ?: @(NO)];
     return point;


### PR DESCRIPTION
Changes the type of point.id to an id rather than NSString. This fixes the crashing ternary when calling an onSnap callback for a point with no id, and also allows for greater flexibility. 