### PR TITLE
Make react-native-interactable compatible with wix/react-native-navigation

### DIFF
--- a/ios/Interactable/InteractableView.m
+++ b/ios/Interactable/InteractableView.m
@@ -235,9 +235,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
                                                                        userData:@{ @"x": @(deltaFromOrigin.x),
                                                                                    @"y": @(deltaFromOrigin.y)}
                                                                   coalescingKey:self.coalescingKey];
-        
-        
-        RCTRootView* rootView = ((RCTRootView*)self.window.rootViewController.view);
+
+
+        RCTRootView *rootView = [self getRootView];
         [[[rootView bridge]eventDispatcher] sendEvent:event];
         
         


### PR DESCRIPTION
Wix/react-native-navigation (and airbnb/native-navigation) rely on having multiple root views,
so we have to find the correct root before sending the animated event. 

Without this fix rn-navigation based apps crash on iOS.