### PR TITLE
Initial attempt at Android alert areas

### DIFF
--- a/android/interactable/src/main/java/com/wix/interactable/Events.java
+++ b/android/interactable/src/main/java/com/wix/interactable/Events.java
@@ -55,4 +55,24 @@ public class Events {
             rctEventEmitter.receiveEvent(getViewTag(), getEventName(), eventData);
         }
     }
+    public static class OnAlertEvent extends Event<OnAlertEvent> {
+
+        WritableMap eventData;
+
+        public OnAlertEvent(int viewTag, String alertAreaId, String alertType) {
+            super(viewTag);
+            eventData = Arguments.createMap();
+            eventData.putString(alertAreaId, alertType);
+        }
+
+        @Override
+        public String getEventName() {
+            return "onAlert";
+        }
+
+        @Override
+        public void dispatch(RCTEventEmitter rctEventEmitter) {
+            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), eventData);
+        }
+    }
 }

--- a/android/interactable/src/main/java/com/wix/interactable/InteractableArea.java
+++ b/android/interactable/src/main/java/com/wix/interactable/InteractableArea.java
@@ -1,4 +1,5 @@
 package com.wix.interactable;
+import android.graphics.PointF;
 
 public class InteractableArea {
     private float top;
@@ -15,6 +16,23 @@ public class InteractableArea {
         this.right = right;
         this.bounce = bounce;
         this.haptics = haptics;
+    }
+
+    public boolean pointInside(PointF point) {
+        float cx = point.x;
+        float cy = point.y;
+
+        if (cx < this.left) return false;
+        if (cx > this.right) return false;
+
+        if (cy < this.top) return false;
+        if (cy > this.bottom) return false;
+
+        return true;
+    }
+
+    public boolean pointInsideWithOrigin(PointF point, PointF origin) {
+        return this.pointInside(new PointF(point.x - origin.x, point.y - origin.y));
     }
 
 

--- a/android/interactable/src/main/java/com/wix/interactable/InteractableViewManager.java
+++ b/android/interactable/src/main/java/com/wix/interactable/InteractableViewManager.java
@@ -58,6 +58,11 @@ public class InteractableViewManager extends ViewGroupManager<InteractableView> 
         view.setFrictionAreas(RNConvert.interactablePoints(frictionAreas));
     }
 
+    @ReactProp(name = "alertAreas")
+    public void setAlertAreas(InteractableView view, @Nullable ReadableArray alertAreas) {
+        view.setAlertAreas(RNConvert.interactablePoints(alertAreas));
+    }
+
     @ReactProp(name = "dragWithSprings")
     public void setDrag(InteractableView view, @Nullable ReadableMap dragWithSprings) {
         view.setDragWithSprings(RNConvert.interactableDrag(dragWithSprings));
@@ -89,6 +94,7 @@ public class InteractableViewManager extends ViewGroupManager<InteractableView> 
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.<String, Object>builder()
                 .put("onSnap", MapBuilder.of("registrationName", "onSnap"))
+                .put("onAlert", MapBuilder.of("registrationName", "onAlert"))
                 .put("onAnimatedEvent", MapBuilder.of("registrationName", "onAnimatedEvent"))
                 .build();
     }
@@ -105,6 +111,11 @@ public class InteractableViewManager extends ViewGroupManager<InteractableView> 
         @Override
         public void onSnap(int indexOfSnapPoint, String snapPointId) {
             eventDispatcher.dispatchEvent(new Events.OnSnapEvent(interactableView.getId(), indexOfSnapPoint, snapPointId));
+        }
+
+        @Override
+        public void onAlert(String alertAreaId, String alertType) {
+            eventDispatcher.dispatchEvent(new Events.OnAlertEvent(interactableView.getId(), alertAreaId, alertType));
         }
 
         @Override


### PR DESCRIPTION
Here's the Android version. I did my best to adhere to the flow of iOS. There were a few differences. Android didn't seem to have an origin, so I didn't use that(pointInsideWithOrigin can be safely deleted, but I wasn't sure if we'd need it). Also, on iOS reportAlertEvent happened inside setCenter, but there was no real setCenter on Android that I could find, so I put the call inside onAnimationFrame. Not sure that was the best place, but it seemed right and it seems to work properly. Let me know if anything seems off.

Oh, and I changed setFrictionAreas to write to a frictionAreas array, instead of gravityPoints, though neither of those seem to be consumed anyway