### PR TITLE
End dragging when dragEnabled is changed to false (Android)

### DIFF
--- a/android/src/main/java/com/wix/interactable/InteractableView.java
+++ b/android/src/main/java/com/wix/interactable/InteractableView.java
@@ -421,6 +421,10 @@ public class InteractableView extends ViewGroup implements PhysicsAnimator.Physi
 
     public void setDragEnabled(boolean dragEnabled) {
         this.dragEnabled = dragEnabled;
+        
+        if (this.dragBehavior != null && !dragEnabled) {
+            handleEndOfDrag();
+        }
     }
 
     public void setInitialPosition(PointF initialPosition) {


### PR DESCRIPTION
As noted in [this comment](https://github.com/wix/react-native-interactable/issues/45#issuecomment-292104113) switching `dragEnabled` from `true` to `false` behaves differently on iOS and Android. This pull request changes the Android version to also stop any dragging when `dragEnabled` if set to `false`.