### PR TITLE
Pass bridge to InteractableView when initializing

### DIFF
--- a/ios/Interactable/InteractableView.h
+++ b/ios/Interactable/InteractableView.h
@@ -8,6 +8,7 @@
 
 #import <UIKit/UIKit.h>
 #import <React/RCTComponent.h>
+#import <React/RCTBridge.h>
 #import "InteractablePoint.h"
 #import "InteractableArea.h"
 #import "InteractableSpring.h"
@@ -18,6 +19,7 @@
 @property (nonatomic, assign) BOOL verticalOnly;
 @property (nonatomic, assign) BOOL horizontalOnly;
 @property (nonatomic, assign) BOOL dragEnabled;
+@property (nonatomic, strong) RCTBridge *bridge;
 @property (nonatomic, copy) NSArray<InteractablePoint *> *snapPoints;
 @property (nonatomic, copy) NSArray<InteractablePoint *> *springPoints;
 @property (nonatomic, copy) NSArray<InteractablePoint *> *gravityPoints;
@@ -33,6 +35,7 @@
 @property (nonatomic, assign) CGPoint initialPosition;
 @property (nonatomic, copy) RCTDirectEventBlock onAnimatedEvent;
 
+- (instancetype)initWithBridge:(RCTBridge*)bridge;
 - (void)setVelocity:(NSDictionary*)params;
 - (void)snapTo:(NSDictionary*)params;
 

--- a/ios/Interactable/InteractableView.m
+++ b/ios/Interactable/InteractableView.m
@@ -103,7 +103,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
 @implementation InteractableView
 
-- (instancetype)init
+- (instancetype)initWithBridge:(RCTBridge *)bridge
 {
     if ((self = [super init]))
     {
@@ -112,6 +112,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
         self.reactRelayoutHappening = NO;
         self.insideAlertAreas = [NSMutableSet set];
         self.dragEnabled = YES;
+        self.bridge = bridge;
         
         // pan gesture recognizer for touches
         self.pan = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePan:)];
@@ -244,9 +245,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
                                                                                    @"y": @(deltaFromOrigin.y)}
                                                                   coalescingKey:self.coalescingKey];
 
-        RCTRootView *rootView = [self getRootView];
-        [[[rootView bridge]eventDispatcher] sendEvent:event];
-        
+        [[self.bridge eventDispatcher] sendEvent:event];
         
         // self.onAnimatedEvent(@
         //                      {

--- a/ios/Interactable/InteractableViewManager.m
+++ b/ios/Interactable/InteractableViewManager.m
@@ -21,7 +21,7 @@ RCT_EXPORT_MODULE()
 
 - (UIView *)view
 {
-    return [[InteractableView alloc] init];
+    return [[InteractableView alloc] initWithBridge:self.bridge];
 }
 
 RCT_EXPORT_VIEW_PROPERTY(verticalOnly, BOOL)


### PR DESCRIPTION
This fixes a bug where animatedValueX/animatedValueY was not working in RN `<Modal>` on iOS.