### PR TITLE
Allow snapping without animation

### DIFF
--- a/android/src/main/java/com/wix/interactable/InteractableView.java
+++ b/android/src/main/java/com/wix/interactable/InteractableView.java
@@ -523,14 +523,23 @@ public class InteractableView extends ViewGroup implements PhysicsAnimator.Physi
     }
 
     public void snapTo(int index) {
+        snapTo(index, true);
+    }
+
+    public void snapTo(int index, boolean animated) {
 
         if(this.snapPoints!=null && index >= 0 && index < this.snapPoints.size())
         {
             this.animator.removeTempBehaviors();
             this.dragBehavior = null;
             InteractablePoint snapPoint = snapPoints.get(index);
-            addTempSnapToPointBehavior(snapPoint);
-            addTempBounceBehaviorWithBoundaries(this.boundaries);
+            if (!animated) {
+                setTranslationX(snapPoint.x);
+                setTranslationY(snapPoint.y);
+            } else {
+                addTempSnapToPointBehavior(snapPoint);
+                addTempBounceBehaviorWithBoundaries(this.boundaries);
+            }
         }
     }
 

--- a/android/src/main/java/com/wix/interactable/InteractableView.java
+++ b/android/src/main/java/com/wix/interactable/InteractableView.java
@@ -536,6 +536,7 @@ public class InteractableView extends ViewGroup implements PhysicsAnimator.Physi
             if (!animated) {
                 setTranslationX(snapPoint.x);
                 setTranslationY(snapPoint.y);
+                setVelocity(new PointF(0, 0));
             } else {
                 addTempSnapToPointBehavior(snapPoint);
                 addTempBounceBehaviorWithBoundaries(this.boundaries);

--- a/android/src/main/java/com/wix/interactable/InteractableViewManager.java
+++ b/android/src/main/java/com/wix/interactable/InteractableViewManager.java
@@ -51,8 +51,13 @@ public class InteractableViewManager extends ViewGroupManager<InteractableView> 
                 return;
             }
             case COMMAND_SNAP_TO: {
-                int snapPoint = args.getMap(0).getInt("index");
-                view.snapTo(snapPoint);
+                ReadableMap params = args.getMap(0);
+                int snapPoint = params.getInt("index");
+                boolean animated = true;
+                if (params.hasKey("animated") {
+                    animated = params.getBoolean("animated");
+                }
+                view.snapTo(snapPoint, animated);
                 return;
             }
             default:

--- a/android/src/main/java/com/wix/interactable/InteractableViewManager.java
+++ b/android/src/main/java/com/wix/interactable/InteractableViewManager.java
@@ -54,7 +54,7 @@ public class InteractableViewManager extends ViewGroupManager<InteractableView> 
                 ReadableMap params = args.getMap(0);
                 int snapPoint = params.getInt("index");
                 boolean animated = true;
-                if (params.hasKey("animated") {
+                if (params.hasKey("animated")) {
                     animated = params.getBoolean("animated");
                 }
                 view.snapTo(snapPoint, animated);

--- a/ios/Interactable/InteractableView.m
+++ b/ios/Interactable/InteractableView.m
@@ -583,6 +583,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
         
         if (!animated) {
             if (snapPoint) self.center = [snapPoint positionWithOrigin:self.origin];
+            [self.animator setTarget:self velocity:CGPointZero];
         } else {
             if (snapPoint) [self addTempSnapToPointBehavior:snapPoint];
             

--- a/ios/Interactable/InteractableView.m
+++ b/ios/Interactable/InteractableView.m
@@ -574,14 +574,21 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
     NSInteger index = [[params objectForKey:@"index"] integerValue];
     if (self.snapPoints && index >= 0 && index < [self.snapPoints count])
     {
+        BOOL animated = [params objectForKey:@"animated"] == nil || [[params objectForKey:@"animated"] boolValue];
+        
         [self.animator removeTempBehaviors];
         self.dragBehavior = nil;
         
         InteractablePoint *snapPoint = [self.snapPoints objectAtIndex:index];
-        if (snapPoint) [self addTempSnapToPointBehavior:snapPoint];
         
-        [self addTempBounceBehaviorWithBoundaries:self.boundaries];
-        [self.animator ensureRunning];
+        if (!animated) {
+            if (snapPoint) self.center = [snapPoint positionWithOrigin:self.origin];
+        } else {
+            if (snapPoint) [self addTempSnapToPointBehavior:snapPoint];
+            
+            [self addTempBounceBehaviorWithBoundaries:self.boundaries];
+            [self.animator ensureRunning];
+        }
     }
 }
 


### PR DESCRIPTION
My use case is that I need to update an intractable view's position while it is just off screen (in a paging scroll view) and I don't want it to be mid snap animation if the user swipes over to the page containing the intractable view.

This is very likely a naive approach. Also, I have only tested this on iOS, since my current project is iOS only right now.