### PR TITLE
Animator respects [horizontal/vertical] only

### DIFF
--- a/ios/Interactable/PhysicsAnimator.h
+++ b/ios/Interactable/PhysicsAnimator.h
@@ -36,4 +36,8 @@
 
 - (void)physicsAnimatorDidPause:(PhysicsAnimator *)animator;
 
+@property (nonatomic, readonly) BOOL horizontalOnly;
+@property (nonatomic, readonly) BOOL verticalOnly;
+
+
 @end

--- a/ios/Interactable/PhysicsAnimator.m
+++ b/ios/Interactable/PhysicsAnimator.m
@@ -155,13 +155,13 @@ const CGFloat ANIMATOR_PAUSE_ZERO_VELOCITY = 1.0;
     {
         PhysicsObject *object = [self.targetsToObjects objectForKey:target];
         CGFloat dx = 0.0;
-        if (ABS(object.velocity.x) > ANIMATOR_PAUSE_ZERO_VELOCITY)
+        if (!self.delegate.verticalOnly && ABS(object.velocity.x) > ANIMATOR_PAUSE_ZERO_VELOCITY)
         {
             dx = deltaTime * object.velocity.x;
             hadMovement = YES;
         }
         CGFloat dy = 0.0;
-        if (ABS(object.velocity.y) > ANIMATOR_PAUSE_ZERO_VELOCITY)
+        if (!self.delegate.horizontalOnly && ABS(object.velocity.y) > ANIMATOR_PAUSE_ZERO_VELOCITY)
         {
             dy = deltaTime * object.velocity.y;
             hadMovement = YES;


### PR DESCRIPTION
I feel like I've just fixed the symptoms here, but I haven't been able to determine why the object.x value isn't converging in my case. Maybe someone could shed some light?

I'm using a `verticalOnly={true}` `Interactable.View`, but on iOS, the animation is very choppy because the Animated.Value is constantly being set back to a snap point because the dx continues to be updated (even though it is later ignored by the `InteractableView`). Not sure how it's getting into this state, but the result is that the animator continues to run, even when the view is "at rest" because the x value continues to have a non-zero velocity.