### PR TITLE
If a symbolic link exists already - recreate

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "start": "node ./node_modules/react-native/local-cli/cli.js start",
     "test": "jest",
-    "postinstall": "ln -s lib/{ios,android} ."
+    "postinstall": "ln -sf lib/{ios,android} ."
   },
   "dependencies": {},
   "peerDependencies": {


### PR DESCRIPTION
Fixes #136 

When `react-native-interactable` is a dependency, first upgrade (of any `yarn upgrade x` dependency) commands:

```
error /Users/tom/src/company/ferocia/native/node_modules/react-native-interactable: Command failed.
Exit code: 1
Command: sh
Arguments: -c ln -s lib/{ios,android} .
Directory: /Users/tom/src/company/ferocia/native/node_modules/react-native-interactable
Output:
ln: ./ios: File exists
ln: ./android: File exists
info Visit https://yarnpkg.com/en/docs/cli/upgrade for documentation about this command.
```

Second command succeeds but first always fails (alternates) due to state.

As per `ln` manpages: 

`-f    If the target file already exists, then unlink it so that the link may occur.`

This will ensure if the link already exists during an upgrade command, remove the old link and recreate.