### PR TITLE
Fix real-life-example android setting.graddle path

### DIFF
--- a/real-life-example/android/settings.gradle
+++ b/real-life-example/android/settings.gradle
@@ -3,4 +3,4 @@ rootProject.name = 'example'
 include ':app'
 
 include ':react-native-interactable'
-project(':react-native-interactable').projectDir = new File(rootProject.projectDir, '../../android')
+project(':react-native-interactable').projectDir = new File(rootProject.projectDir, '../../lib/android')


### PR DESCRIPTION
The path that lead to react-native-interactable android project in real-life-example android setting.graddle is wrong. Its suppose to be ../../lib/android according to your code.