### PR TITLE
Add a return value to onDrag callback.

### DIFF
--- a/PROPS.md
+++ b/PROPS.md
@@ -158,6 +158,7 @@ Optional, a function called whenever the user starts or stops dragging the view.
 * `state` - `start` or `end`, whether the user started or finished dragging.
 * `x` - The horizontal position of the view (relative to the center).
 * `y` - The vertical position of the view (relative to the center).
+* `targetSnapPointId` - For `end` state, the string `id` of the target point in the `snapPoints` array (assuming it was provided). Otherwise, empty string.
 
 #### `onAlert` (function)
 

--- a/lib/android/src/main/java/com/wix/interactable/Events.java
+++ b/lib/android/src/main/java/com/wix/interactable/Events.java
@@ -80,12 +80,13 @@ public class Events {
 
         WritableMap eventData;
 
-        public onDrag(int viewTag, String state, float x, float y) {
+        public onDrag(int viewTag, String state, float x, float y, String targetSnapPointId) {
             super(viewTag);
             eventData = Arguments.createMap();
             eventData.putString("state", state);
             eventData.putDouble("x", PixelUtil.toDIPFromPixel(x));
             eventData.putDouble("y", PixelUtil.toDIPFromPixel(y));
+            eventData.putString("targetSnapPointId", targetSnapPointId);
         }
 
         @Override

--- a/lib/android/src/main/java/com/wix/interactable/InteractableView.java
+++ b/lib/android/src/main/java/com/wix/interactable/InteractableView.java
@@ -279,7 +279,7 @@ public class InteractableView extends ViewGroup implements PhysicsAnimator.Physi
 
     private void startDrag(MotionEvent ev) {
         PointF currentPosition = getCurrentPosition();
-        listener.onDrag("start",currentPosition.x, currentPosition.y);
+        listener.onDrag("start",currentPosition.x, currentPosition.y, '');
         this.dragStartLocation = new PointF(ev.getX(),ev.getY());
         this.animator.removeTempBehaviors();
         this.animator.setDragging(true);
@@ -304,12 +304,12 @@ public class InteractableView extends ViewGroup implements PhysicsAnimator.Physi
         if (this.dragWithSprings != null) toss = this.dragWithSprings.toss;
 
         PointF currentPosition = getCurrentPosition();
-        listener.onDrag("end",currentPosition.x, currentPosition.y);
 
         PointF projectedCenter = new PointF(getTranslationX() + toss*velocity.x,
                 getTranslationY() + toss*velocity.y);
 
         InteractablePoint snapPoint = InteractablePoint.findClosestPoint(snapPoints,projectedCenter);
+        listener.onDrag("end",currentPosition.x, currentPosition.y, snapPoint.id);
 
         addTempSnapToPointBehavior(snapPoint);
         addTempBounceBehaviorWithBoundaries(this.boundaries);
@@ -547,6 +547,6 @@ public class InteractableView extends ViewGroup implements PhysicsAnimator.Physi
         void onSnap(int indexOfSnapPoint, String snapPointId);
         void onAlert(String alertAreaId, String alertType);
         void onAnimatedEvent(float x, float y);
-        void onDrag(String state, float x, float y);
+        void onDrag(String state, float x, float y, String targetSnapPointId);
     }
 }

--- a/lib/android/src/main/java/com/wix/interactable/InteractableView.java
+++ b/lib/android/src/main/java/com/wix/interactable/InteractableView.java
@@ -279,7 +279,7 @@ public class InteractableView extends ViewGroup implements PhysicsAnimator.Physi
 
     private void startDrag(MotionEvent ev) {
         PointF currentPosition = getCurrentPosition();
-        listener.onDrag("start",currentPosition.x, currentPosition.y, '');
+        listener.onDrag("start",currentPosition.x, currentPosition.y, "");
         this.dragStartLocation = new PointF(ev.getX(),ev.getY());
         this.animator.removeTempBehaviors();
         this.animator.setDragging(true);

--- a/lib/android/src/main/java/com/wix/interactable/InteractableViewManager.java
+++ b/lib/android/src/main/java/com/wix/interactable/InteractableViewManager.java
@@ -179,8 +179,8 @@ public class InteractableViewManager extends ViewGroupManager<InteractableView> 
         }
 
         @Override
-        public void onDrag(String state, float x, float y) {
-            eventDispatcher.dispatchEvent(new Events.onDrag(interactableView.getId(),state, x, y));
+        public void onDrag(String state, float x, float y, String targetSnapPointId) {
+            eventDispatcher.dispatchEvent(new Events.onDrag(interactableView.getId(),state, x, y, targetSnapPointId));
         }
     }
 }


### PR DESCRIPTION
Add targetSnapPointId to onDrag callback - both platforms.
targetSnapPointId - For end state, the string id of the target point in the snapPoints array (assuming it was provided). Otherwise, an empty string.
The value is the snap point id which is the destination of the object.