### PR TITLE
Remove old boundaries when setting new ones

### DIFF
--- a/lib/android/src/main/java/com/wix/interactable/InteractableView.java
+++ b/lib/android/src/main/java/com/wix/interactable/InteractableView.java
@@ -45,6 +45,8 @@ public class InteractableView extends ViewGroup implements PhysicsAnimator.Physi
     private PointF initialPosition;
 
     private InteractableArea boundaries;
+    private PhysicsBounceBehavior oldBoundariesBehavior;
+
     private InteractableSpring dragWithSprings;
     private float dragToss;
     private PointF velocity;
@@ -367,6 +369,7 @@ public class InteractableView extends ViewGroup implements PhysicsAnimator.Physi
             PhysicsBounceBehavior bounceBehavior = new PhysicsBounceBehavior(this,minPoint, maxPoint,0, boundaries.isHaptic());
 
             this.animator.addBehavior(bounceBehavior);
+            this.oldBoundariesBehavior = bounceBehavior;
         }
     }
 
@@ -468,6 +471,7 @@ public class InteractableView extends ViewGroup implements PhysicsAnimator.Physi
 
     public void setBoundaries(InteractableArea boundaries) {
         this.boundaries = boundaries;
+        animator.removeBehavior(this.oldBoundariesBehavior);
         addConstantBoundaries(boundaries);
     }
 

--- a/lib/android/src/main/java/com/wix/interactable/physics/PhysicsAnimator.java
+++ b/lib/android/src/main/java/com/wix/interactable/physics/PhysicsAnimator.java
@@ -79,6 +79,17 @@ public class PhysicsAnimator implements Choreographer.FrameCallback {
         ensureRunning();
     }
 
+    public void removeBehavior(PhysicsBehavior behavior) {
+        Iterator<PhysicsBehavior> iterator = behaviors.iterator();
+
+        while (iterator.hasNext()) {
+            if (iterator.next() == behavior) {
+                iterator.remove();
+                break;
+            }
+        }
+    }
+
     public void addTempBehavior(PhysicsBehavior behavior) {
         behavior.isTemp = true;
         addBehavior(behavior);


### PR DESCRIPTION
As reported in #155, boundaries are not updated on Android. 
After few investigations, I have understood that boundaries are added as non-temp behaviors and hence are accumulated over time in `PhysicsAnimator animator`. Hence even if the boundary property changes in react, it will not replace the old boundary constraint but rather be added to it.
My solution simply consists in keeping a reference on the previous boundary and remove it as soon as a new one is set to keep only one of them.
It might not be the most sophisticated way of doing so but it was sufficient for me and seems to work exactly as expected.