### PR TITLE
Update build.gradle

### DIFF
--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -45,3 +45,13 @@ dependencies {
     // node_modules
     compile 'com.facebook.react:react-native:+'
 }
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+    jcenter()
+    maven {
+      // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+      url "$projectDir/../../../node_modules/react-native/android"
+    }
+}


### PR DESCRIPTION
After integrating this library with native-navigation of bamlab -https://github.com/bamlab/native-navigation, on android platform, i got the underlying error
```
            super(viewTag);
            ^
    constructor Event.Event() is not applicable
      (actual and formal argument lists differ in length)
    constructor Event.Event(int,long) is not applicable
      (actual and formal argument lists differ in length)```

I fixed it by making some config changes in android/build.gradle & it's working now.