### PR TITLE
Fixing INativeAlertEvent typing (it's a dictionary)

### DIFF
--- a/typings/react-native-interactable.d.ts
+++ b/typings/react-native-interactable.d.ts
@@ -103,10 +103,10 @@ declare module 'react-native-interactable' {
     type NativeAlertEventLeaveValueType = 'leave';
     type NativeAlertEventValue = NativeAlertEventEnterValueType | NativeAlertEventLeaveValueType;
 
-    type NativeAlertEvent = { [id: string]: NativeAlertEventValue }
+    interface INativeAlertEvent { [id: string]: NativeAlertEventValue }
 
     interface IAlertEvent {
-      nativeEvent: NativeAlertEvent;
+      nativeEvent: INativeAlertEvent;
     }
 
     interface IInteractableView extends ViewProperties {

--- a/typings/react-native-interactable.d.ts
+++ b/typings/react-native-interactable.d.ts
@@ -103,13 +103,10 @@ declare module 'react-native-interactable' {
     type NativeAlertEventLeaveValueType = 'leave';
     type NativeAlertEventValue = NativeAlertEventEnterValueType | NativeAlertEventLeaveValueType;
 
-    interface INativeAlertEvent {
-      id: string;
-      value: NativeAlertEventValue;
-    }
+    type NativeAlertEvent = { [id: string]: NativeAlertEventValue }
 
     interface IAlertEvent {
-      nativeEvent: INativeAlertEvent;
+      nativeEvent: NativeAlertEvent;
     }
 
     interface IInteractableView extends ViewProperties {


### PR DESCRIPTION
INativeAlertEvent was typed as {id, value} object but runtime actually provides a dictionary/map <string, NativeAlertEventValue>