### PR TITLE
iOS App Store Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ To run the example, clone the repo and run from the root folder:<br>
   react-native run-ios
 ```
 
-* **Install and run the demo app from the App Store/Google Play on your phone**
-<br><br>If you don't want to mess with building yourself, you can play with a pre-built demo on your phone.
-<br><br>Download from [Apple App Store (iOS)](https://itunes.apple.com/us/app/react-native-interactions/id1209875831?ls=1&mt=8)<br>Download from [Google Play Store (Android)](https://play.google.com/store/apps/details?id=com.wix.interactions&hl=en)
+* **Install and run the demo app from the Google Play store on your phone**
+<br><br>If you don't want to mess with building yourself, you can play with a pre-built demo on your Android phone (Apple's app store prohibits demo apps, unfortunately).
+<br><br>Download from [Google Play Store (Android)](https://play.google.com/store/apps/details?id=com.wix.interactions&hl=en)
 <br><br><img src="http://i.imgur.com/VpSsavS.gif" width=200 />&nbsp;&nbsp;&nbsp;&nbsp;<img src="http://i.imgur.com/O7ulJa1.gif" width=200 />&nbsp;&nbsp;&nbsp;&nbsp;<img src="http://i.imgur.com/2mrUNIM.gif" width=200 />
 
 * **Build and run the demo app on your computer**


### PR DESCRIPTION
Link is broken, I assume because Apple took down the app due to noncompliance (their rules prohibit demo apps).