### PR TITLE
attempt to heal #146

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "start": "node ./node_modules/react-native/local-cli/cli.js start",
     "test": "jest",
-    "postinstall": "ln -sf lib/{ios,android} ."
+    "postinstall": "bash -c 'ln -sf lib/{ios,android} .'"
   },
   "dependencies": {},
   "peerDependencies": {


### PR DESCRIPTION
Force postinstall to use `bash` to address #146 which created invalid symlinks on Linux.