### PR TITLE
Fix for issue #101: iOS - onSnap

### DIFF
--- a/lib/ios/Interactable/InteractableView.m
+++ b/lib/ios/Interactable/InteractableView.m
@@ -201,9 +201,12 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
     }
 }
 
+
+// MARK: - PhysicsAnimatorDelegate
+
 - (void)physicsAnimatorDidPause:(PhysicsAnimator *)animator
 {
-    if (self.onSnap)
+    if (self.onSnap && self.pan.state == UIGestureRecognizerStatePossible )
     {
         InteractablePoint *snapPoint = [InteractablePoint findClosestPoint:self.snapPoints toPoint:self.center withOrigin:self.origin];
         if (snapPoint)
@@ -226,6 +229,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
                     });
     }
 }
+
+// MARK: - Reports
 
 - (void)reportAnimatedEvent
 {


### PR DESCRIPTION
 onSnap is called when drag is paused but not yet completed (i.e. when snap did not yet occur).