### PR TITLE
Fixing yellow warning in react-native-interactable (forked the librar…

### DIFF
--- a/lib/src/InteractableView.js
+++ b/lib/src/InteractableView.js
@@ -73,7 +73,7 @@ class WrappedAnimatedInteractableView extends Component {
     } else if (Platform.OS === 'android') {
       UIManager.dispatchViewManagerCommand(
         ReactNative.findNodeHandle(this),
-        UIManager.InteractableView.Commands.setVelocity,
+        UIManager.getViewManagerConfig('InteractableView').Commands.setVelocity,
         [params],
       );
     }
@@ -85,7 +85,7 @@ class WrappedAnimatedInteractableView extends Component {
     } else if (Platform.OS === 'android') {
       UIManager.dispatchViewManagerCommand(
         ReactNative.findNodeHandle(this),
-        UIManager.InteractableView.Commands.snapTo,
+        UIManager.getViewManagerConfig('InteractableView').Commands.snapTo,
         [params],
       );
     }
@@ -97,7 +97,7 @@ class WrappedAnimatedInteractableView extends Component {
     } else if (Platform.OS === 'android') {
       UIManager.dispatchViewManagerCommand(
         ReactNative.findNodeHandle(this),
-        UIManager.InteractableView.Commands.changePosition,
+        UIManager.getViewManagerConfig('InteractableView').Commands.changePosition,
         [params],
       );
     }
@@ -107,7 +107,7 @@ class WrappedAnimatedInteractableView extends Component {
     if (Platform.OS === 'android') {
       UIManager.dispatchViewManagerCommand(
         ReactNative.findNodeHandle(this),
-        UIManager.InteractableView.Commands.bringToFront,
+        UIManager.getViewManagerConfig('InteractableView').Commands.bringToFront,
         [],
       );
     }


### PR DESCRIPTION
When using this library with the latest version of **ReactNative** (e.g. **0.58**) we get the following warning:

`Accessing view manager configs directly off UIManager via UIManager['InteractableView'] is no longer supported.`

This pull request applies the necessary modifications for fixing the problem.
