### PR TITLE
Add junit and android test runner dependencies for androidTest

### DIFF
--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -41,7 +41,8 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     testImplementation 'junit:junit:4.12'
-
+    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
     // node_modules
     implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
Currently `androidTest` is missing two dependencies and trying to compile fails. 