### PR TITLE
use initialPosition on init

### DIFF
--- a/lib/ios/Interactable/InteractableView.m
+++ b/lib/ios/Interactable/InteractableView.m
@@ -156,7 +156,11 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
         center = CGPointMake(self.origin.x - self.reactRelayoutCenterDeltaFromOrigin.x, self.origin.y - self.reactRelayoutCenterDeltaFromOrigin.y);
     }
     
-    if (self.originSet)
+    if (!self.initialPositionSet)
+    {
+        center = CGPointMake(self.origin.x + self.initialPosition.x, self.origin.y + self.initialPosition.y);
+    }
+    else if (self.originSet)
     {
         if (self.horizontalOnly) center.y = self.origin.y;
         if (self.verticalOnly) center.x = self.origin.x;


### PR DESCRIPTION
During initialization, `setCenter` is called twice:
1) by React, initialized to `(0,0)`
2) by InteractableView, initialized to the `initialPosition`

Occasionally, the second event is not received on the react-native side (https://github.com/wix/react-native-interactable/issues/269). This PR makes the first event initialize to the initialPosition.