### PR TITLE
types: add types for ref use

### DIFF
--- a/typings/react-native-interactable.d.ts
+++ b/typings/react-native-interactable.d.ts
@@ -133,6 +133,22 @@ declare module 'react-native-interactable' {
       style?: ViewStyle;
     }
 
+    interface CoordinatesParams {
+      x?: number;
+      y?: number;
+    }
+
+    interface SnapToParams {
+      index: number;
+    }
+
+    interface InteractableViewComponent extends React.Component<IInteractableView> {
+      setVelocity: (params: CoordinatesParams) => void;
+      snapTo: (params: SnapToParams) => void;
+      changePosition: (params: CoordinatesParams) => void;
+      bringToFront: () => void;
+    }
+
     interface IInteractable {
       View: new () => React.Component<IInteractableView, {}>;
     }


### PR DESCRIPTION
For people using typescript, that wants to use `ref=` and autocompletion on `this.myRef.current` exposing the methods of the InteractableView

```
myRef = createRef<InteractableViewComponent>();
...
openDrawer = () => {
if (!this.myRef.current) {
    return;
}
this.myRef.current.snapTo({ index: 0 });
}
...
<Interactable.View
   ref={this.myRef}
```

