### PR TITLE
autolinking improvement for android

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  dependency: {
+    platforms: {
+      android: {
+      	sourceDir: 'lib/android'
+      }
+    }
+  }
+};


### PR DESCRIPTION
With this config file cli will be able to find the sourceDir for android. This will fix `Invariant Violation requireNativeComponent 'InteractableView' was not found in UiManager.` error for RN >= 0.60.

Autolinking works well for iOS if you have the [`Interactable.podspec`](https://github.com/wix/react-native-interactable/blame/master/Interactable.podspec) file. But if you add the library from `npm` (v1.0.0) for some reason it won't be added. So make sure you have `podspec` file in the root of the library before running `pod install`