### PR TITLE
fix(ios): make it possible to install via CocoaPods

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -87,9 +87,6 @@ fabric.properties
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
-#Cocoapods
-*.podspec
-
 ## Build generated
 ios/build/
 ios/DerivedData/


### PR DESCRIPTION
The podspec file was npm ignored, resulting in linking via CocaPods did not work

Originally by @sondremare (#276). Original PR had some git reference messup (detached head, unreachable by CI, caused this PR build to fail).