### PR TITLE
Update .npmignore to exclude android tests

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,5 @@
 .ghp/
-
+scripts/
 
 playground
 e2e
@@ -185,6 +185,10 @@ android/captures/
 
 # Keystore files
 *.jks
+
+# Test
+lib/android/src/test/
+lib/android/src/androidTest/
 
 ##################
 # React-Native


### PR DESCRIPTION
I've just integrated an e2e test using a detox, and `assembleAndroidTest`  failed because this project publish own tests)



**To test:**

```sh
npm pack --dry-run &| grep -i "test"
```