### PR TITLE
AppTheme is too generic

### DIFF
--- a/lib/android/src/main/AndroidManifest.xml
+++ b/lib/android/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
 
     <application
         android:label="@string/app_name"
-        android:theme="@style/AppTheme">
+        android:theme="@style/RNInteractableTheme">
     </application>
 
 </manifest>


### PR DESCRIPTION
AppTheme is too generic and causes manifest merge errors, make it more custom.